### PR TITLE
Add torch placement tweak and mixin plugin

### DIFF
--- a/src/main/java/io/github/cottonmc/cotton/CottonMixinPlugin.java
+++ b/src/main/java/io/github/cottonmc/cotton/CottonMixinPlugin.java
@@ -1,0 +1,63 @@
+package io.github.cottonmc.cotton;
+
+import com.google.common.collect.ImmutableMap;
+import io.github.cottonmc.cotton.config.ConfigManager;
+import io.github.cottonmc.cotton.config.CottonConfig;
+import org.spongepowered.asm.lib.tree.ClassNode;
+import org.spongepowered.asm.mixin.extensibility.IMixinConfigPlugin;
+import org.spongepowered.asm.mixin.extensibility.IMixinInfo;
+
+import java.util.List;
+import java.util.Set;
+import java.util.function.BooleanSupplier;
+
+/**
+ * Used for loading config-dependent mixins. INTERNAL.
+ */
+public class CottonMixinPlugin implements IMixinConfigPlugin {
+    private static final String PACKAGE = "io.github.cottonmc.cotton.mixin";
+
+    // Using Cotton.config would require loading Fabric's mixins (because of the commonGroup field).
+    // That won't be done yet when this class loads.
+    private static final CottonConfig CONFIG = ConfigManager.loadConfig(CottonConfig.class);
+    private static final ImmutableMap<String, BooleanSupplier> MIXIN_STATES =
+        ImmutableMap.of(
+            PACKAGE + ".TorchBlockMixin", () -> CONFIG.enable_custom_torch_placement
+        );
+
+    @Override
+    public void onLoad(String mixinPackage) {
+        if (!mixinPackage.startsWith(PACKAGE)) {
+            throw new IllegalArgumentException(
+                String.format("Invalid package: Expected %s, found %s", PACKAGE, mixinPackage)
+            );
+        }
+    }
+
+    @Override
+    public boolean shouldApplyMixin(String targetClassName, String mixinClassName) {
+        BooleanSupplier supplier = MIXIN_STATES.get(mixinClassName);
+        // If the supplier is not found, ignore it and return true
+        return supplier == null || supplier.getAsBoolean();
+    }
+
+    // Boring boilerplate below
+
+    @Override
+    public List<String> getMixins() {
+        // null = loaded from the JSON
+        return null;
+    }
+
+    @Override
+    public void acceptTargets(Set<String> myTargets, Set<String> otherTargets) {}
+
+    @Override
+    public String getRefMapperConfig() { return null; }
+
+    @Override
+    public void preApply(String targetClassName, ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo) {}
+
+    @Override
+    public void postApply(String targetClassName, ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo) {}
+}

--- a/src/main/java/io/github/cottonmc/cotton/CottonMixinPlugin.java
+++ b/src/main/java/io/github/cottonmc/cotton/CottonMixinPlugin.java
@@ -22,7 +22,7 @@ public class CottonMixinPlugin implements IMixinConfigPlugin {
     private static final CottonConfig CONFIG = ConfigManager.loadConfig(CottonConfig.class);
     private static final ImmutableMap<String, BooleanSupplier> MIXIN_STATES =
         ImmutableMap.of(
-            PACKAGE + ".TorchBlockMixin", () -> CONFIG.enable_custom_torch_placement
+            PACKAGE + ".TorchBlockMixin", () -> CONFIG.include_tweaks && CONFIG.enable_custom_torch_placement
         );
 
     @Override

--- a/src/main/java/io/github/cottonmc/cotton/config/CottonConfig.java
+++ b/src/main/java/io/github/cottonmc/cotton/config/CottonConfig.java
@@ -28,7 +28,8 @@ public class CottonConfig {
     @Comment("Enable dispenser tweaks, like seed planting?")
     public boolean enable_dispenser_tweaks = true;
 
-    @Comment("Enable the shape-based torch placement algorithm.")
+    @Comment("Enable the shape-based torch placement algorithm. " +
+            "Allows you to place torches on more blocks.")
     public boolean enable_custom_torch_placement = true;
 
 }

--- a/src/main/java/io/github/cottonmc/cotton/config/CottonConfig.java
+++ b/src/main/java/io/github/cottonmc/cotton/config/CottonConfig.java
@@ -28,4 +28,7 @@ public class CottonConfig {
     @Comment("Enable dispenser tweaks, like seed planting?")
     public boolean enable_dispenser_tweaks = true;
 
+    @Comment("Enable the shape-based torch placement algorithm.")
+    public boolean enable_custom_torch_placement = true;
+
 }

--- a/src/main/java/io/github/cottonmc/cotton/config/CottonConfig.java
+++ b/src/main/java/io/github/cottonmc/cotton/config/CottonConfig.java
@@ -28,7 +28,7 @@ public class CottonConfig {
     @Comment("Enable dispenser tweaks, like seed planting?")
     public boolean enable_dispenser_tweaks = true;
 
-    @Comment("Enable the shape-based torch placement algorithm. " +
+    @Comment("Tweaks: Enable the shape-based torch placement algorithm. " +
             "Allows you to place torches on more blocks.")
     public boolean enable_custom_torch_placement = true;
 

--- a/src/main/java/io/github/cottonmc/cotton/mixin/TorchBlockMixin.java
+++ b/src/main/java/io/github/cottonmc/cotton/mixin/TorchBlockMixin.java
@@ -13,8 +13,11 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 
+/* Allows placing torches on more blocks by checking their collision shape
+* if they can't be placed otherwise. */
 @Mixin(TorchBlock.class)
 public class TorchBlockMixin {
+    // This is as wide as a fence post and 0.5/16 blocks tall.
     private static final BoundingBox TOP_BOX = Block.createCuboidShape(6, 15.5, 6, 10, 16, 10).getBoundingBox();
 
     /**

--- a/src/main/java/io/github/cottonmc/cotton/mixin/TorchBlockMixin.java
+++ b/src/main/java/io/github/cottonmc/cotton/mixin/TorchBlockMixin.java
@@ -1,0 +1,39 @@
+package io.github.cottonmc.cotton.mixin;
+
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockState;
+import net.minecraft.block.TorchBlock;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.BoundingBox;
+import net.minecraft.util.shape.VoxelShape;
+import net.minecraft.world.ViewableWorld;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
+
+@Mixin(TorchBlock.class)
+public class TorchBlockMixin {
+    private static final BoundingBox TOP_BOX = Block.createCuboidShape(6, 15.5, 6, 10, 16, 10).getBoundingBox();
+
+    /**
+     * Checks if the inner BoundingBox is contained in any of the
+     * BoundingBoxes of the outer VoxelShape.
+     */
+    private static boolean containedIn(VoxelShape outer, BoundingBox inner) {
+        return outer.getBoundingBoxList().stream().anyMatch(box ->
+            box.minX <= inner.minX && box.maxX >= inner.maxX &&
+                box.minY <= inner.minY && box.maxY >= inner.maxY &&
+                box.minZ <= inner.minZ && box.maxZ >= inner.maxZ
+        );
+    }
+
+    @Inject(method = "canPlaceAt", at = @At("RETURN"), cancellable = true, locals = LocalCapture.CAPTURE_FAILHARD)
+    private void onCanPlaceAt(BlockState state, ViewableWorld world, BlockPos pos, CallbackInfoReturnable<Boolean> info,
+                              BlockPos downPos, BlockState downState, Block downBlock) {
+        if (!info.getReturnValue()) {
+            info.setReturnValue(containedIn(downState.getCollisionShape(world, downPos), TOP_BOX));
+        }
+    }
+}

--- a/src/main/java/io/github/cottonmc/cotton/mixin/TorchBlockMixin.java
+++ b/src/main/java/io/github/cottonmc/cotton/mixin/TorchBlockMixin.java
@@ -14,7 +14,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 
 /* Allows placing torches on more blocks by checking their collision shape
-* if they can't be placed otherwise. */
+* if they can't be placed otherwise. (not including wall torches) */
 @Mixin(TorchBlock.class)
 public class TorchBlockMixin {
     // This is as wide as a fence post and 0.5/16 blocks tall.

--- a/src/main/resources/cotton.common.json
+++ b/src/main/resources/cotton.common.json
@@ -4,7 +4,7 @@
   "plugin": "io.github.cottonmc.cotton.CottonMixinPlugin",
   "compatibilityLevel": "JAVA_8",
   "mixins": [
-    "MainMenuScreenMixin"
+    "TorchBlockMixin"
   ],
   "injectors": {
     "defaultRequire": 1

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -10,6 +10,7 @@
     "fabric": "*"
   },
   "mixins": {
-    "client": "cotton.client.json"
+    "client": "cotton.client.json",
+    "common": "cotton.common.json"
   }
 }


### PR DESCRIPTION
Adds a custom torch placement algorithm that uses the collision shape of the block below to check if a torch can be placed on top.

The mixin plugin can be used to make mixin loading depend on config values.