### PR TITLE
Add a generic base class for cooking-like recipes with bonus items, and a common crushing recipe implementation

### DIFF
--- a/src/main/java/io/github/cottonmc/cotton/datapack/recipe/CookingWithBonusRecipe.java
+++ b/src/main/java/io/github/cottonmc/cotton/datapack/recipe/CookingWithBonusRecipe.java
@@ -1,0 +1,120 @@
+package io.github.cottonmc.cotton.datapack.recipe;
+
+import com.google.gson.JsonObject;
+import net.minecraft.item.ItemStack;
+import net.minecraft.recipe.Ingredient;
+import net.minecraft.recipe.RecipeSerializer;
+import net.minecraft.recipe.RecipeType;
+import net.minecraft.recipe.cooking.CookingRecipe;
+import net.minecraft.recipe.crafting.ShapedRecipe;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.PacketByteBuf;
+import net.minecraft.world.loot.LootManager;
+import net.minecraft.world.loot.context.LootContext;
+
+import java.util.Collections;
+import java.util.List;
+
+import static net.minecraft.util.JsonHelper.*;
+
+/**
+ * Implements a generic machine processing recipe with optional loot table for bonus items.
+ *
+ * Example JSON:
+ *
+ * {
+ *     "type": "c:example",
+ *     "ingredient": {
+ *         "item": "minecraft:iron_ore"
+ *     },
+ *     "result": {
+ *         "item": "example:iron_dust",
+ *         "count": 2
+ *     },
+ *     "bonus_loot_table": "example:iron_ore_to_dust_bonuses"
+ * }
+ *
+ * @see CrushingRecipe for an example implementation
+ */
+public abstract class CookingWithBonusRecipe extends CookingRecipe {
+
+	private final Identifier bonusLootTable;
+
+	public CookingWithBonusRecipe(RecipeType<?> type, Identifier id, String group, Ingredient input, ItemStack output, float exp, int cookingTime, Identifier bonusLootTable) {
+		super(type, id, group, input, output, exp, cookingTime);
+		this.bonusLootTable = bonusLootTable;
+	}
+
+	public Identifier getBonusLootTable() {
+		return bonusLootTable;
+	}
+
+	public List<ItemStack> craftBonus(LootManager lootManager, LootContext lootContext) {
+		if (bonusLootTable == null)
+			return Collections.emptyList();
+		return lootManager.getSupplier(bonusLootTable).getDrops(lootContext);
+	}
+
+	@FunctionalInterface
+	public interface Factory<R extends CookingWithBonusRecipe> {
+		R create(Identifier id, String group, Ingredient input, ItemStack output, float exp, int cookingTime, Identifier bonusLootTable);
+	}
+
+	public static class Serializer<R extends CookingWithBonusRecipe> implements RecipeSerializer<R> {
+
+		private final Factory<R> factory;
+		private final int defaultCookTime;
+
+		public Serializer(Factory<R> factory, int defaultCookTime) {
+			this.factory = factory;
+			this.defaultCookTime = defaultCookTime;
+		}
+
+		@Override
+		public R read(Identifier id, JsonObject jsonObject) {
+			String group = getString(jsonObject, "group", "");
+
+			Ingredient input = Ingredient.fromJson(
+					hasArray(jsonObject, "ingredient")
+							? getArray(jsonObject, "ingredient")
+							: getObject(jsonObject, "ingredient")
+			);
+
+			ItemStack output = ShapedRecipe.getItemStack(getObject(jsonObject, "result"));
+			float exp = getFloat(jsonObject, "experience", 0.0F);
+			int cookTime = getInt(jsonObject, "cookingtime", this.defaultCookTime);
+
+			String bonusLoot = getString(jsonObject, "bonus_loot_table", null);
+			Identifier bonusLootId = bonusLoot == null ? null : Identifier.create(bonusLoot);
+
+			R r = factory.create(id, group, input, output, exp, cookTime, bonusLootId);
+			return r;
+		}
+
+		@Override
+		public R read(Identifier id, PacketByteBuf buffer) {
+			String group = buffer.readString(32767);
+			Ingredient input = Ingredient.fromPacket(buffer);
+			ItemStack output = buffer.readItemStack();
+			float exp = buffer.readFloat();
+			int cookTime = buffer.readVarInt();
+			Identifier bonusLoot = buffer.readBoolean() ? buffer.readIdentifier() : null;
+			return factory.create(id, group, input, output, exp, cookTime, bonusLoot);
+		}
+
+		@Override
+		public void write(PacketByteBuf buffer, R recipe) {
+			buffer.writeString(recipe.group);
+			recipe.input.write(buffer);
+			buffer.writeItemStack(recipe.output);
+			buffer.writeFloat(recipe.experience);
+			buffer.writeVarInt(recipe.cookTime);
+
+			Identifier bonusLoot = recipe.getBonusLootTable();
+			buffer.writeBoolean(bonusLoot != null);
+			if (bonusLoot != null) {
+				buffer.writeIdentifier(bonusLoot);
+			}
+		}
+	}
+}

--- a/src/main/java/io/github/cottonmc/cotton/datapack/recipe/CottonRecipes.java
+++ b/src/main/java/io/github/cottonmc/cotton/datapack/recipe/CottonRecipes.java
@@ -13,7 +13,7 @@ public class CottonRecipes {
 	public static final RecipeSerializer<NullRecipe> NULL_SERIALIZER = register("null", new SpecialRecipeSerializer<>(NullRecipe::new));
 
 	public static final RecipeType<CrushingRecipe> CRUSHING_RECIPE = register("crushing");
-	public static final RecipeSerializer<CrushingRecipe> CRUSHING_SERIALIZER = register("crushing", new CookingWithBonusRecipe.Serializer<>(CrushingRecipe::new, 100));
+	public static final RecipeSerializer<CrushingRecipe> CRUSHING_SERIALIZER = register("crushing", new ProcessingRecipe.Serializer<>(CrushingRecipe::new, 100));
 
 	public static <T extends Recipe<?>> RecipeType<T> register(String id) {
 		return Registry.register(Registry.RECIPE_TYPE, new Identifier(Cotton.SHARED_NAMESPACE, id), new RecipeType<T>() {

--- a/src/main/java/io/github/cottonmc/cotton/datapack/recipe/CottonRecipes.java
+++ b/src/main/java/io/github/cottonmc/cotton/datapack/recipe/CottonRecipes.java
@@ -10,10 +10,13 @@ import net.minecraft.util.registry.Registry;
 
 public class CottonRecipes {
 	public static final RecipeType<NullRecipe> NULL_RECIPE = register("null");
-	public static RecipeSerializer<NullRecipe> NULL_SERIALIZER = register("null", new SpecialRecipeSerializer<>(NullRecipe::new));
+	public static final RecipeSerializer<NullRecipe> NULL_SERIALIZER = register("null", new SpecialRecipeSerializer<>(NullRecipe::new));
+
+	public static final RecipeType<CrushingRecipe> CRUSHING_RECIPE = register("crushing");
+	public static final RecipeSerializer<CrushingRecipe> CRUSHING_SERIALIZER = register("crushing", new CookingWithBonusRecipe.Serializer<>(CrushingRecipe::new, 100));
 
 	public static <T extends Recipe<?>> RecipeType<T> register(String id) {
-		return Registry.register(Registry.RECIPE_TYPE, new Identifier(Cotton.MODID, id), new RecipeType<T>() {
+		return Registry.register(Registry.RECIPE_TYPE, new Identifier(Cotton.SHARED_NAMESPACE, id), new RecipeType<T>() {
 			public String toString() {
 				return id;
 			}
@@ -21,7 +24,7 @@ public class CottonRecipes {
 	}
 
 	public static <S extends RecipeSerializer<T>, T extends Recipe<?>> S register(String name, S serializer) {
-		return Registry.register(Registry.RECIPE_SERIALIZER, new Identifier(Cotton.MODID, name), serializer);
+		return Registry.register(Registry.RECIPE_SERIALIZER, new Identifier(Cotton.SHARED_NAMESPACE, name), serializer);
 	}
 
 	public static void init() {

--- a/src/main/java/io/github/cottonmc/cotton/datapack/recipe/CrushingRecipe.java
+++ b/src/main/java/io/github/cottonmc/cotton/datapack/recipe/CrushingRecipe.java
@@ -3,12 +3,18 @@ package io.github.cottonmc.cotton.datapack.recipe;
 import net.minecraft.item.ItemStack;
 import net.minecraft.recipe.Ingredient;
 import net.minecraft.recipe.RecipeSerializer;
+import net.minecraft.recipe.RecipeType;
 import net.minecraft.util.Identifier;
 
-public class CrushingRecipe extends CookingWithBonusRecipe {
+public class CrushingRecipe extends ProcessingRecipe {
 
-	public CrushingRecipe(Identifier id, String group, Ingredient input, ItemStack output, float exp, int cookingTime, Identifier bonusLootTable) {
-		super(CottonRecipes.CRUSHING_RECIPE, id, group, input, output, exp, cookingTime, bonusLootTable);
+	public CrushingRecipe(Identifier id, Ingredient input, ItemStack output, float exp, int processTime, Identifier bonusLootTable) {
+		super(id, input, output, exp, processTime, bonusLootTable);
+	}
+
+	@Override
+	public RecipeType<?> getType() {
+		return CottonRecipes.CRUSHING_RECIPE;
 	}
 
 	@Override

--- a/src/main/java/io/github/cottonmc/cotton/datapack/recipe/CrushingRecipe.java
+++ b/src/main/java/io/github/cottonmc/cotton/datapack/recipe/CrushingRecipe.java
@@ -1,0 +1,18 @@
+package io.github.cottonmc.cotton.datapack.recipe;
+
+import net.minecraft.item.ItemStack;
+import net.minecraft.recipe.Ingredient;
+import net.minecraft.recipe.RecipeSerializer;
+import net.minecraft.util.Identifier;
+
+public class CrushingRecipe extends CookingWithBonusRecipe {
+
+	public CrushingRecipe(Identifier id, String group, Ingredient input, ItemStack output, float exp, int cookingTime, Identifier bonusLootTable) {
+		super(CottonRecipes.CRUSHING_RECIPE, id, group, input, output, exp, cookingTime, bonusLootTable);
+	}
+
+	@Override
+	public RecipeSerializer<?> getSerializer() {
+		return CottonRecipes.CRUSHING_SERIALIZER;
+	}
+}

--- a/src/main/java/io/github/cottonmc/cotton/datapack/recipe/NullRecipe.java
+++ b/src/main/java/io/github/cottonmc/cotton/datapack/recipe/NullRecipe.java
@@ -28,7 +28,7 @@ public class NullRecipe extends SpecialCraftingRecipe {
 	}
 
 	@Override
-	public RecipeSerializer<?> getSerializer() {
-		return null;
+	public RecipeSerializer<NullRecipe> getSerializer() {
+		return CottonRecipes.NULL_SERIALIZER;
 	}
 }


### PR DESCRIPTION
As discussed in the Fabric discord.

It's pretty common for tech and tech-like mods to have some form of crushing system, and to work with each others' items. This `c:crushing` recipe type implemented by the `CrushingRecipe` class provides a common place for people to define crushing recipes that should work across all mods that consume it.

The `ProcessingRecipe` class is a convenient base class for any type of one-to-one recipe that may support bonus items. Think standard machine processing recipes, but also exploding/burning recipes in Composable Automation, or anything else that processes one item into another. 

If merged, I'll add ore -> dust recipes to cotton-resources.

I also made the recipe types shipping with Cotton use the shared namespace, since it seems to be the right place for it. I can remove that change if I've misunderstood the purpose of the shared namespace.