### PR TITLE
Some changes to CottonScreen

### DIFF
--- a/src/main/java/io/github/cottonmc/cotton/gui/client/CottonScreen.java
+++ b/src/main/java/io/github/cottonmc/cotton/gui/client/CottonScreen.java
@@ -6,8 +6,8 @@ import io.github.cottonmc.cotton.gui.widget.WWidget;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.ContainerScreen;
 import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.text.StringTextComponent;
 import net.minecraft.text.TextComponent;
-import net.minecraft.text.TranslatableTextComponent;
 import net.minecraft.util.Nameable;
 
 public class CottonScreen<T extends CottonScreenController> extends ContainerScreen<T> {
@@ -16,7 +16,7 @@ public class CottonScreen<T extends CottonScreenController> extends ContainerScr
 	protected WWidget lastResponder = null;
 	
 	public CottonScreen(T container, PlayerEntity player) {
-		super(container, player.inventory, new TranslatableTextComponent(""));
+		super(container, player.inventory, new StringTextComponent(""));
 		this.container = container;
 		width = 18*9;
 		height = 18*9;
@@ -204,6 +204,8 @@ public class CottonScreen<T extends CottonScreenController> extends ContainerScr
 		if (container instanceof Nameable) {
 			TextComponent name = ((Nameable)container).getDisplayName();
 			font.draw(name.getFormattedText(), left, top, container.getTitleColor());
+		} else if (getTitle() != null) {
+			font.draw(getTitle().getFormattedText(), left, top, container.getTitleColor());
 		}
 	}
 	


### PR DESCRIPTION
- Switches to `StringTextComponent`s instead of `TranslatableTextComponent`s in the constructor
- Adds support for drawing the screen title if it is set

The support for drawing the screen title is for supporting `NameableContainerProvider`s for GUI creation. The vanilla container system (`ContainerType` and friends) expects containers to be created with that type.