### PR TITLE
Fix duplicated GUI slots being created by CottonScreen

### DIFF
--- a/src/main/java/io/github/cottonmc/cotton/gui/client/CottonScreen.java
+++ b/src/main/java/io/github/cottonmc/cotton/gui/client/CottonScreen.java
@@ -51,6 +51,10 @@ public class CottonScreen<T extends CottonScreenController> extends ContainerScr
 	public void reposition() {
 		WPanel basePanel = container.getRootPanel();
 		if (basePanel!=null) {
+			// Validating the root panel will recreate the WItemSlot's peers,
+			// so this will remove the current ones.
+			container.slotList.clear();
+
 			basePanel.validate(container);
 			
 			containerWidth = basePanel.getWidth();


### PR DESCRIPTION
Currently, `CottonScreen.reposition` will append new `Slot` instances to the controller's slot list every time that it is called. That causes duplicate slots on the client, and breaks dropping items from GUIs (because the server doesn't have those extra slots).

Not 100% sure about the fix, though, but it works.