### PR TITLE
Add machine loot context type for processing recipes

### DIFF
--- a/src/main/java/io/github/cottonmc/cotton/Cotton.java
+++ b/src/main/java/io/github/cottonmc/cotton/Cotton.java
@@ -6,7 +6,6 @@ import io.github.cottonmc.cotton.datapack.PackMetaManager;
 import io.github.cottonmc.cotton.datapack.recipe.CottonRecipes;
 import io.github.cottonmc.cotton.datapack.recipe.RecipeUtil;
 import io.github.cottonmc.cotton.logging.ModLogger;
-import io.github.cottonmc.cotton.loot.CottonLootContextTypes;
 import io.github.cottonmc.cotton.registry.CommonTags;
 import io.github.cottonmc.cotton.tweaker.*;
 import net.fabricmc.api.ModInitializer;
@@ -59,7 +58,6 @@ public class Cotton implements ModInitializer {
 		//example datapack manager code
 		CommonTags.init();
 		RecipeUtil.init(config);
-		CottonLootContextTypes.init();
 //		TagEntryManager.registerToTag(TagType.BLOCK, new Identifier("minecraft:enderman_holdable"), "minecraft:string");
 //		TagEntryManager.registerToTag(TagType.BLOCK, new Identifier("minecraft:dragon_immune"), "#minecraft:enderman_holdable");
 //		LootTableManager.registerBasicBlockDropTable(new Identifier("minecraft", "dirt"));

--- a/src/main/java/io/github/cottonmc/cotton/Cotton.java
+++ b/src/main/java/io/github/cottonmc/cotton/Cotton.java
@@ -6,6 +6,7 @@ import io.github.cottonmc.cotton.datapack.PackMetaManager;
 import io.github.cottonmc.cotton.datapack.recipe.CottonRecipes;
 import io.github.cottonmc.cotton.datapack.recipe.RecipeUtil;
 import io.github.cottonmc.cotton.logging.ModLogger;
+import io.github.cottonmc.cotton.loot.CottonLootContextTypes;
 import io.github.cottonmc.cotton.registry.CommonTags;
 import io.github.cottonmc.cotton.tweaker.*;
 import net.fabricmc.api.ModInitializer;
@@ -58,6 +59,7 @@ public class Cotton implements ModInitializer {
 		//example datapack manager code
 		CommonTags.init();
 		RecipeUtil.init(config);
+		CottonLootContextTypes.init();
 //		TagEntryManager.registerToTag(TagType.BLOCK, new Identifier("minecraft:enderman_holdable"), "minecraft:string");
 //		TagEntryManager.registerToTag(TagType.BLOCK, new Identifier("minecraft:dragon_immune"), "#minecraft:enderman_holdable");
 //		LootTableManager.registerBasicBlockDropTable(new Identifier("minecraft", "dirt"));

--- a/src/main/java/io/github/cottonmc/cotton/datapack/recipe/ProcessingRecipe.java
+++ b/src/main/java/io/github/cottonmc/cotton/datapack/recipe/ProcessingRecipe.java
@@ -47,6 +47,11 @@ public abstract class ProcessingRecipe implements Recipe<Inventory> {
 	protected final ItemStack output;
 	protected final float exp;
 	protected final int processTime;
+
+	/**
+	 * A loot table for bonus drops.
+	 * It should use the {@link io.github.cottonmc.cotton.loot.CottonLootContextTypes#MACHINE cotton:machine} loot type.
+	 */
 	protected final Identifier bonusLootTable;
 
 	public ProcessingRecipe(Identifier id, Ingredient input, ItemStack output, float exp, int processTime, Identifier bonusLootTable) {

--- a/src/main/java/io/github/cottonmc/cotton/loot/CottonLootContextTypes.java
+++ b/src/main/java/io/github/cottonmc/cotton/loot/CottonLootContextTypes.java
@@ -1,14 +1,7 @@
 package io.github.cottonmc.cotton.loot;
 
-import com.google.common.collect.BiMap;
-import net.minecraft.util.Identifier;
-import net.minecraft.util.Lazy;
 import net.minecraft.world.loot.context.LootContextParameters;
 import net.minecraft.world.loot.context.LootContextType;
-import net.minecraft.world.loot.context.LootContextTypes;
-
-import java.lang.reflect.Field;
-import java.util.Arrays;
 
 public final class CottonLootContextTypes {
 	public static final LootContextType MACHINE = new LootContextType.Builder()
@@ -16,27 +9,4 @@ public final class CottonLootContextTypes {
 			.require(LootContextParameters.BLOCK_STATE)
 			.require(LootContextParameters.POSITION)
 			.build();
-
-	@SuppressWarnings("unchecked")
-	private static final Lazy<BiMap<Identifier, LootContextType>> REGISTRY = new Lazy<>(() -> {
-		try {
-			Field field = Arrays.stream(LootContextTypes.class.getDeclaredFields())
-					.filter(f -> BiMap.class.isAssignableFrom(f.getType()))
-					.findAny()
-					.orElseThrow(() -> new RuntimeException("Could not find BiMap field in LootContextTypes"));
-
-			field.setAccessible(true);
-			return (BiMap<Identifier, LootContextType>) field.get(null);
-		} catch (Exception e) {
-			throw new RuntimeException("Could not find LootContextType registry", e);
-		}
-	});
-
-	public static void init() {
-		register(new Identifier("cotton", "machine"), MACHINE);
-	}
-
-	private static void register(Identifier id, LootContextType type) {
-		REGISTRY.get().put(id, type);
-	}
 }

--- a/src/main/java/io/github/cottonmc/cotton/loot/CottonLootContextTypes.java
+++ b/src/main/java/io/github/cottonmc/cotton/loot/CottonLootContextTypes.java
@@ -1,0 +1,42 @@
+package io.github.cottonmc.cotton.loot;
+
+import com.google.common.collect.BiMap;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.Lazy;
+import net.minecraft.world.loot.context.LootContextParameters;
+import net.minecraft.world.loot.context.LootContextType;
+import net.minecraft.world.loot.context.LootContextTypes;
+
+import java.lang.reflect.Field;
+import java.util.Arrays;
+
+public final class CottonLootContextTypes {
+	public static final LootContextType MACHINE = new LootContextType.Builder()
+			.require(LootContextParameters.BLOCK_ENTITY)
+			.require(LootContextParameters.BLOCK_STATE)
+			.require(LootContextParameters.POSITION)
+			.build();
+
+	@SuppressWarnings("unchecked")
+	private static final Lazy<BiMap<Identifier, LootContextType>> REGISTRY = new Lazy<>(() -> {
+		try {
+			Field field = Arrays.stream(LootContextTypes.class.getDeclaredFields())
+					.filter(f -> BiMap.class.isAssignableFrom(f.getType()))
+					.findAny()
+					.orElseThrow(() -> new RuntimeException("Could not find BiMap field in LootContextTypes"));
+
+			field.setAccessible(true);
+			return (BiMap<Identifier, LootContextType>) field.get(null);
+		} catch (Exception e) {
+			throw new RuntimeException("Could not find LootContextType registry", e);
+		}
+	});
+
+	public static void init() {
+		register(new Identifier("cotton", "machine"), MACHINE);
+	}
+
+	private static void register(Identifier id, LootContextType type) {
+		REGISTRY.get().put(id, type);
+	}
+}

--- a/src/main/java/io/github/cottonmc/cotton/mixins/MixinLootContextTypes.java
+++ b/src/main/java/io/github/cottonmc/cotton/mixins/MixinLootContextTypes.java
@@ -1,0 +1,23 @@
+package io.github.cottonmc.cotton.mixins;
+
+import com.google.common.collect.BiMap;
+import io.github.cottonmc.cotton.loot.CottonLootContextTypes;
+import net.minecraft.util.Identifier;
+import net.minecraft.world.loot.context.LootContextType;
+import net.minecraft.world.loot.context.LootContextTypes;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(LootContextTypes.class)
+public abstract class MixinLootContextTypes {
+	@Shadow @Final private static BiMap<Identifier, LootContextType> MAP;
+
+	@Inject(method = "<clinit>", at = @At("RETURN"))
+	private static void onClinit(CallbackInfo info) {
+		MAP.put(new Identifier("cotton", "machine"), CottonLootContextTypes.MACHINE);
+	}
+}

--- a/src/main/resources/cotton.common.json
+++ b/src/main/resources/cotton.common.json
@@ -9,7 +9,8 @@
     "MixinBucketItem",
     "MixinRecipeManager",
     "MixinPlayerEntity",
-    "MixinResourceManagerImpl"
+    "MixinResourceManagerImpl",
+    "MixinLootContextTypes"
   ],
   "client": [
     "MixinCottonInitializerClient"


### PR DESCRIPTION
Adds a loot context type, `cotton:machine` for processing recipes, with a block state, a block entity and a position as required parameters. Closes #28.