### PR TITLE
Switch to unique identifiers in virtual resource packs

### DIFF
--- a/src/main/java/io/github/cottonmc/cotton/Cotton.java
+++ b/src/main/java/io/github/cottonmc/cotton/Cotton.java
@@ -52,7 +52,7 @@ public class Cotton implements ModInitializer {
 		//register the command that prints out the virtual data and resource packs.
 		CommandRegistry.INSTANCE.register(false, new PackPrinterCommand());
 
-		/*
+        /*
 		HashMap<String, InputStreamProvider> map = new HashMap<>();
 		map.put("assets/minecraft/blockstates/cobblestone.json", InputStreamProvider.of(() -> "{\n" +
 				"    \"variants\": {\n" +
@@ -60,10 +60,10 @@ public class Cotton implements ModInitializer {
 				"    }\n" +
 				"}\n"));
 		VirtualResourcePackManager.INSTANCE.addPack(
-				new VirtualResourcePack("test", map),
-				Collections.singleton(ResourceType.CLIENT_RESOURCES)
+				new VirtualResourcePack(new Identifier("cotton", "test"), map),
+                Arrays.asList(ResourceType.values())
 		);
-		*/
+        */
 
 //		TagEntryManager.registerToTag(TagType.BLOCK, new Identifier("minecraft:enderman_holdable"), "minecraft:string");
 //		TagEntryManager.registerToTag(TagType.BLOCK, new Identifier("minecraft:dragon_immune"), "#minecraft:enderman_holdable");

--- a/src/main/java/io/github/cottonmc/cotton/Cotton.java
+++ b/src/main/java/io/github/cottonmc/cotton/Cotton.java
@@ -52,7 +52,7 @@ public class Cotton implements ModInitializer {
 		//register the command that prints out the virtual data and resource packs.
 		CommandRegistry.INSTANCE.register(false, new PackPrinterCommand());
 
-        /*
+		/*
 		HashMap<String, InputStreamProvider> map = new HashMap<>();
 		map.put("assets/minecraft/blockstates/cobblestone.json", InputStreamProvider.of(() -> "{\n" +
 				"    \"variants\": {\n" +
@@ -61,9 +61,9 @@ public class Cotton implements ModInitializer {
 				"}\n"));
 		VirtualResourcePackManager.INSTANCE.addPack(
 				new VirtualResourcePack(new Identifier("cotton", "test"), map),
-                Arrays.asList(ResourceType.values())
+				Arrays.asList(ResourceType.values())
 		);
-        */
+		*/
 
 //		TagEntryManager.registerToTag(TagType.BLOCK, new Identifier("minecraft:enderman_holdable"), "minecraft:string");
 //		TagEntryManager.registerToTag(TagType.BLOCK, new Identifier("minecraft:dragon_immune"), "#minecraft:enderman_holdable");

--- a/src/main/java/io/github/cottonmc/cotton/datapack/virtual/VirtualResourcePack.java
+++ b/src/main/java/io/github/cottonmc/cotton/datapack/virtual/VirtualResourcePack.java
@@ -33,7 +33,7 @@ public class VirtualResourcePack extends AbstractFileResourcePack {
 	private static final Pattern NAMESPACE_PATTERN = Pattern.compile("(?:.+?)/(.+?)/.+");
 	private final Set<String> namespaces;
 	private final Map<String, InputStreamProvider> contents;
-	private final String id;
+	private final Identifier id;
 
 	/**
 	 * The constructor.
@@ -41,7 +41,7 @@ public class VirtualResourcePack extends AbstractFileResourcePack {
 	 * @param id       an identifier for this data pack (does not have to be unique)
 	 * @param contents the contents as a [resource path]=>[contents] map
 	 */
-	public VirtualResourcePack(String id, Map<String, InputStreamProvider> contents) {
+	public VirtualResourcePack(Identifier id, Map<String, InputStreamProvider> contents) {
 		super(null);
 		this.id = id;
 		this.namespaces = contents.keySet().stream()
@@ -106,11 +106,14 @@ public class VirtualResourcePack extends AbstractFileResourcePack {
 		return String.format("%s (virtual)", id);
 	}
 
-	String getId(int index) {
-		return String.format("virtual/%d_%s", index, id);
-	}
+    /**
+     * @return the id of this resource pack
+     */
+    public Identifier getId() {
+        return id;
+    }
 
-	@Nullable
+    @Nullable
 	@Override
 	public <T> T parseMetadata(ResourceMetadataReader<T> reader) {
 		JsonObject packMetadata = new JsonObject();
@@ -131,6 +134,10 @@ public class VirtualResourcePack extends AbstractFileResourcePack {
 		return null;
 	}
 
+    /**
+     * Gets the contents of this pack as a file path -> input stream provider map.
+     * @return the contents
+     */
 	public ImmutableMap<String, InputStreamProvider> getContents() {
 		return ImmutableMap.copyOf(contents);
 	}

--- a/src/main/java/io/github/cottonmc/cotton/datapack/virtual/VirtualResourcePack.java
+++ b/src/main/java/io/github/cottonmc/cotton/datapack/virtual/VirtualResourcePack.java
@@ -168,14 +168,10 @@ public class VirtualResourcePack extends AbstractFileResourcePack {
 	 * @return a unique pack id
 	 */
 	private static Identifier convertToUniqueId(String str) {
-		int colonIndex = str.indexOf(':');
-		boolean hasNamespace = colonIndex != -1 && colonIndex < str.length() - 1;
-		Identifier result = hasNamespace ? Identifier.ofNullable(str) : null; // Identifier.tryParse() in 1.14.3
+		Identifier result = Identifier.ofNullable(str); // Identifier.tryParse() in 1.14.3
 
 		if (result == null) {
-			String namespace = hasNamespace ? filterValidIdChars(str.substring(0, colonIndex)) : "unknown";
-			String path = filterValidIdChars(hasNamespace ? str.substring(colonIndex + 1) : str);
-			result = new Identifier(namespace, path);
+			result = new Identifier("unknown", filterValidIdChars(str));
 		}
 
 		int index = VirtualResourcePackManager.INSTANCE.getPackIds().size();

--- a/src/main/java/io/github/cottonmc/cotton/datapack/virtual/VirtualResourcePack.java
+++ b/src/main/java/io/github/cottonmc/cotton/datapack/virtual/VirtualResourcePack.java
@@ -67,9 +67,9 @@ public class VirtualResourcePack extends AbstractFileResourcePack {
 	 * @param contents the contents as a [resource path]=>[contents] map
 	 */
 	@Deprecated
-    public VirtualResourcePack(String id, Map<String, InputStreamProvider> contents) {
-	    this(convertToUniqueId(id), contents);
-    }
+	public VirtualResourcePack(String id, Map<String, InputStreamProvider> contents) {
+		this(convertToUniqueId(id), contents);
+	}
 
 	@Override
 	protected InputStream openFile(String s) throws IOException {
@@ -118,14 +118,14 @@ public class VirtualResourcePack extends AbstractFileResourcePack {
 		return String.format("%s (virtual)", id);
 	}
 
-    /**
-     * @return the id of this resource pack
-     */
-    public Identifier getId() {
-        return id;
-    }
+	/**
+	 * @return the id of this resource pack
+	 */
+	public Identifier getId() {
+		return id;
+	}
 
-    @Nullable
+	@Nullable
 	@Override
 	public <T> T parseMetadata(ResourceMetadataReader<T> reader) {
 		JsonObject packMetadata = new JsonObject();
@@ -146,10 +146,11 @@ public class VirtualResourcePack extends AbstractFileResourcePack {
 		return null;
 	}
 
-    /**
-     * Gets the contents of this pack as a file path -> input stream provider map.
-     * @return the contents
-     */
+	/**
+	 * Gets the contents of this pack as a file path -> input stream provider map.
+	 *
+	 * @return the contents
+	 */
 	public ImmutableMap<String, InputStreamProvider> getContents() {
 		return ImmutableMap.copyOf(contents);
 	}
@@ -169,17 +170,17 @@ public class VirtualResourcePack extends AbstractFileResourcePack {
 	private static Identifier convertToUniqueId(String str) {
 		int colonIndex = str.indexOf(':');
 		boolean hasNamespace = colonIndex != -1 && colonIndex < str.length() - 1;
-        Identifier result = hasNamespace ? Identifier.ofNullable(str) : null; // Identifier.tryParse() in 1.14.3
+		Identifier result = hasNamespace ? Identifier.ofNullable(str) : null; // Identifier.tryParse() in 1.14.3
 
-        if (result == null) {
-        	String namespace = hasNamespace ? filterValidIdChars(str.substring(0, colonIndex)) : "unknown";
-        	String path = filterValidIdChars(hasNamespace ? str.substring(colonIndex + 1) : str);
+		if (result == null) {
+			String namespace = hasNamespace ? filterValidIdChars(str.substring(0, colonIndex)) : "unknown";
+			String path = filterValidIdChars(hasNamespace ? str.substring(colonIndex + 1) : str);
 			result = new Identifier(namespace, path);
-        }
+		}
 
-        int index = VirtualResourcePackManager.INSTANCE.getPackIds().size();
-        return Identifiers.suffixPath(result, "_" + index);
-    }
+		int index = VirtualResourcePackManager.INSTANCE.getPackIds().size();
+		return Identifiers.suffixPath(result, "_" + index);
+	}
 
 	/**
 	 * Filters the input string by checking each character

--- a/src/main/java/io/github/cottonmc/cotton/datapack/virtual/VirtualResourcePackManager.java
+++ b/src/main/java/io/github/cottonmc/cotton/datapack/virtual/VirtualResourcePackManager.java
@@ -54,7 +54,7 @@ public enum VirtualResourcePackManager {
 		if (types.isEmpty()) {
 			throw new IllegalArgumentException("Trying to add virtual resource pack with no types");
 		} else if (packIds.contains(pack.getId())) {
-			throw new IllegalArgumentException(String.format("Duplicate virtual resource pack ID: %s", pack.getId()));
+			throw new IllegalArgumentException("Duplicate virtual resource pack ID: " + pack.getId());
 		}
 
 		for (ResourceType type : types) {

--- a/src/main/java/io/github/cottonmc/cotton/datapack/virtual/VirtualResourcePackManager.java
+++ b/src/main/java/io/github/cottonmc/cotton/datapack/virtual/VirtualResourcePackManager.java
@@ -21,11 +21,10 @@ public enum VirtualResourcePackManager {
 		return new ResourcePackCreator() {
 			@Override
 			public <T extends ResourcePackContainer> void registerContainer(Map<String, T> map, ResourcePackContainer.Factory<T> factory) {
-				int i = 0;
 				for (PackContainer packContainer : packs.get(type)) {
 					VirtualResourcePack pack = packContainer.getPack();
 					ClientResourcePackMode clientPackMode = packContainer.getClientPackMode();
-					String id = pack.getId(i++);
+					String id = "virtual/" + pack.getId();
 					T container = ResourcePackContainer.of(
 							id,
 							type == ResourceType.CLIENT_RESOURCES && clientPackMode == ClientResourcePackMode.ALWAYS_ENABLED,
@@ -54,6 +53,12 @@ public enum VirtualResourcePackManager {
 		}
 
 		for (ResourceType type : types) {
+		    for (PackContainer existing : packs.get(type)) {
+		        if (existing.getPack().getId().equals(pack.getId())) {
+		            throw new IllegalArgumentException(String.format("Duplicate resource pack ID for type %s: %s", type.getName(), pack.getId()));
+                }
+            }
+
 			packs.put(type, new PackContainer(pack, clientPackMode));
 		}
 	}


### PR DESCRIPTION
The old constructor for `VirtualResourcePack` is kept and deprecated, and the old id strings are converted to unique identifiers in the `unknown` namespace unless they're valid identifiers.