### PR TITLE
Allow using subdirectories in config folder

### DIFF
--- a/modules/cotton-config/src/main/java/io/github/cottonmc/cotton/config/ConfigManager.java
+++ b/modules/cotton-config/src/main/java/io/github/cottonmc/cotton/config/ConfigManager.java
@@ -115,9 +115,10 @@ public class ConfigManager {
 
         try {
             File file = FabricLoader.getInstance().getConfigDirectory().toPath().resolve(configName).toFile();
-            if(!file.exists())
+            if(!file.exists()) {
+                file.mkdirs();
                 file.createNewFile();
-
+            }
             FileOutputStream out = new FileOutputStream(file,false);
 
             out.write(result.getBytes());


### PR DESCRIPTION
Some projects might require multiple configs in one directory, and as result will require to use `bar/FooConfig` to put it in the `config/bar` folder. This PR aims to fix the IOException raised when this directory does not exist.