### PR TITLE
Stop pulling modmenu for dependants

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,7 @@ dependencies {
 
     // For ModMenu compatibility tests
     modImplementation "net.fabricmc.fabric-api:fabric-api:0.3.0+build.200"
-    modImplementation "io.github.prospector.modmenu:ModMenu:1.6.3-94"
+    modRuntime "io.github.prospector.modmenu:ModMenu:1.6.3-94"
 }
 
 


### PR DESCRIPTION
From a quick look you don't use the ModMenu API so you don't need to compile against it, but verify that's the case.