### PR TITLE
Remove ModMenu, update Loom, and fix Fabric API version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,9 +48,7 @@ dependencies {
 
     compileOnly ("com.google.code.findbugs:jsr305:3.0.2") { transitive = false }
 
-    // For ModMenu compatibility tests
     modImplementation "net.fabricmc.fabric-api:fabric-api:0.4.30+build.294-1.16"
-    modImplementation "io.github.prospector.modmenu:ModMenu:1.6.3-94"
 }
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id "com.jfrog.artifactory" version "4.9.0"
     id "maven-publish"
-    id "fabric-loom" version "0.2.6-SNAPSHOT"
+    id "fabric-loom" version "0.2.7-SNAPSHOT"
 }
 
 def minecraftVersion = "1.15.2"
@@ -35,6 +35,7 @@ dependencies {
     minecraft "com.mojang:minecraft:$minecraftVersion"
     mappings "net.fabricmc:yarn:$yarnMappings"
     modImplementation "net.fabricmc:fabric-loader:$loaderVersion"
+    modImplementation "net.fabricmc.fabric-api:fabric-api:0.11.1+build.312-1.15"
 
     // `modApi`s below are for the dev env
     def modules = ["player-events", "logging", "config", "datapack", "commons", "cauldron"]
@@ -47,8 +48,6 @@ dependencies {
     include "io.github.cottonmc:Jankson-Fabric:2.0.1+j1.2.0"
 
     compileOnly ("com.google.code.findbugs:jsr305:3.0.2") { transitive = false }
-
-    modImplementation "net.fabricmc.fabric-api:fabric-api:0.4.30+build.294-1.16"
 }
 
 


### PR DESCRIPTION
# Changes
 - Remove ModMenu (No idea who added it)
 - Update Loom to 0.2.7-SNAPSHOT
 - Change Fabric API version from 1.16 to 1.15 (Again, no idea who thought it would be a good idea to change the version to 1.16 on the 1.15 branch 😂)

Linked to #41 

And yes, I can confirm it works. I have tested it and it has succeeded with no errors (Mac OS X 10.13.6).