### PR TITLE
Sets the mod to a library

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -14,6 +14,9 @@
     "issues": "https://github.com/CottonMC/cotton/issues"
   },
   "custom": {
-    "modmenu:api": true
+    "modmenu:api": true,
+    "modmenu": {
+      "badges": "library"
+    }
   }
 }


### PR DESCRIPTION
Did this because I use a mod that uses (jar in jar's) cotton and cotton shows up in modmenu even when i hide libraries. Idk whether this is necessary, the correct way to do it or anything else, so just propose changes and I will likely accept them. You could probably just copy in the code because it's such a small change, i dont care.